### PR TITLE
Fix Recycle Bin Bug Properly Using CLSID

### DIFF
--- a/Files/WinSux.ps1
+++ b/Files/WinSux.ps1
@@ -2557,9 +2557,7 @@ $Shortcut.Save()
 # create recycle bin shortcut
 $WshShell = New-Object -ComObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut("$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Recycle Bin.lnk")
-$Shortcut.TargetPath = "$env:SystemRoot\explorer.exe"
-$Shortcut.Arguments = "shell:RecycleBinFolder"
-$Shortcut.IconLocation = "%SystemRoot%\System32\imageres.dll,265"
+$Shortcut.TargetPath = '::{645ff040-5081-101b-9f08-00aa002f954e}'
 $Shortcut.Save()
 
 # hide accessibility accessories folders and all contents from start menu


### PR DESCRIPTION
creating the shortcut using the recycle bin universal clsid as the target path creates a proper shortcut (same as if you did it manually by right clicking recycle bin)

*tested in script and working*

<img width="992" height="715" alt="{7400A8B5-DF84-4926-82C9-D94E4C66150C}" src="https://github.com/user-attachments/assets/4971f780-2f5d-43c8-81f9-49a8c40c04d1" />
