### PR TITLE
Fix Edge Uninstall Not Working When Using Blocked Region

### DIFF
--- a/Files/WinSux.ps1
+++ b/Files/WinSux.ps1
@@ -2587,7 +2587,7 @@ $OGValue = Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersio
 #create fake reg.exe
 Copy-Item (Get-Command reg.exe).Source .\reg1.exe -Force -EA 0
 #set device region to usa
-& .\reg1.exe add 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DeviceRegion' /v DeviceRegion /t REG_DWORD /d 244 /f 
+& .\reg1.exe add 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DeviceRegion' /v DeviceRegion /t REG_DWORD /d 244 /f >$null
 
 # find edgeupdate.exe
 $edgeupdate = @(); "LocalApplicationData", "ProgramFilesX86", "ProgramFiles" | ForEach-Object {
@@ -2657,7 +2657,7 @@ dism /online /Remove-Package /PackageName:$EdgeLegacyPackage /quiet /norestart 2
 
 #reset value
 if ($OGValue) {
-& .\reg1.exe add 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DeviceRegion' /v DeviceRegion /t REG_DWORD /d $OGValue /f 
+& .\reg1.exe add 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DeviceRegion' /v DeviceRegion /t REG_DWORD /d $OGValue /f >$null
 }
 #cleanup fake reg.exe
 Remove-Item .\reg1.exe -ErrorAction SilentlyContinue


### PR DESCRIPTION
this fixes the issue where edge uninstall is blocked due to the device region selected during setup

the device region key is protected by a hardcoded list of processes from editing it... by just making reg.exe into reg1.exe we can change this key to somewhere edge can be uninstalled (usa works)

you can test the script before this fix when using a region like hungary:

*sets device region to hungary*
```powershell
Copy-Item (Get-Command reg.exe).Source .\reg1.exe -Force -EA 0
& .\reg1.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DeviceRegion" /v DeviceRegion /t REG_DWORD /d 109 /f 
```

<img width="438" height="78" alt="image" src="https://github.com/user-attachments/assets/380e631c-2276-428a-8968-d32c5ab936e6" />
